### PR TITLE
guard: Create exception on empty guard file

### DIFF
--- a/libguard/guard_exception.hpp
+++ b/libguard/guard_exception.hpp
@@ -25,6 +25,12 @@ class GuardException : public std::exception
     std::string message;
 };
 
+class InvalidGuardFile : public GuardException
+{
+  public:
+    explicit InvalidGuardFile(const std::string& msg) : GuardException(msg){};
+};
+
 class GuardFileOpenFailed : public GuardException
 {
   public:

--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -42,8 +42,17 @@ void initialize()
         {
             guard_log(GUARD_ERROR, "Fail to find guard file %s",
                       GUARD_PRSV_PATH);
+            std::string exceptionLog("Guard file does not exist at ");
+            exceptionLog += GUARD_PRSV_PATH;
+            throw InvalidGuardFile(exceptionLog);
         }
         guardFilePath = GUARD_PRSV_PATH;
+    }
+    if (fs::file_size(guardFilePath) == 0)
+    {
+        std::string exceptionLog("Empty Guard file ");
+        exceptionLog += GUARD_PRSV_PATH;
+        throw InvalidGuardFile(exceptionLog);
     }
 #ifndef PGUARD
     // validate magic number, read from 0th position


### PR DESCRIPTION
-Currently whenever the guard file is empty or does not exist, it terminates with an exception.

-Added the new execption InvalidGuardFile to address the issue

-Catching the exception enables us to generate the PEL and "User Data 1" provides more information regarding the exception

Tested:
Point to dummy file instead of actual guard file
Using the above error in the ipl callback, able to generate the below PEL {
"0x50000E0C": {
"SRC": "BD8D300B",
"Message": "Guard file empty or does not exist",
"PLID": "0x50000E0C",
"CreatorID": "BMC",
"Subsystem": "BMC Firmware",
"Commit Time": "10/06/2022 12:33:57",
"Sev": "Predictive Error",
"CompID": "0x3000"
}
}
...
...
"Error Details": {
"Message": "Guard file empty or does not exist"
},
"Callout Section": {
"Callout Count": "1",
"Callouts": [{
"FRU Type": "Maintenance Procedure Required",
"Priority": "Mandatory, replace all with this type as a unit",
"Procedure": "BMC0001"
}]
}
},
...
"LOG013 2022-10-06 12:33:57": "Guard file
/var/lib/phosphor-software-manager/hostfw/running/NOFILE does not exist", "_PID": "4393"
}

Signed-off-by: deepakala deepakala.karthikeyan@ibm.com
Change-Id: Id5c0368847a9b0abccccf53992e950309697bc9b